### PR TITLE
Process Slack links

### DIFF
--- a/src/processing/WebhookReceiver.js
+++ b/src/processing/WebhookReceiver.js
@@ -26,6 +26,7 @@ class WebhookReceiver {
                 require("./layers/message/from_webhook"),
                 require("./layers/message/from_slack_attachments"),
                 require("./layers/message/emoji"),
+                require("./layers/message/slack_links"),
                 require("./layers/message/html"),
                 require("./layers/message/slack_fallback"),
                 require("./layers/message/html_fallback"),

--- a/src/processing/layers/message/slack_links.js
+++ b/src/processing/layers/message/slack_links.js
@@ -1,0 +1,23 @@
+module.exports = (webhook, matrix) => {
+    // Reference: https://api.slack.com/docs/message-formatting#linking_to_urls
+    // Slack also accepts e.g. <example.com|DISPLAY_STR> but that results in a relative path
+
+    // Match <PROTOCOL://REST_OF_URL|DISPLAY_STR>
+    const linkRegex = /<([a-zA-Z]+):\/\/([^|>]+?)\|([^|>]+?)>/g;
+    // Match <PROTOCOL://REST_OF_URL>
+    const linkRegex2 = /<([a-zA-Z]+):\/\/([^|>]+?)>/g;
+    // Match <mailto:ADDRESS|DISPLAY_STR>
+    const mailtoRegex = /<mailto:([^|>]+?)\|([^|>]+?)>/g;
+    // Match <mailto:ADDRESS>
+    const mailtoRegex2 = /<mailto:([^|>]+?)>/g;
+
+    // Apply regex'es
+    matrix.event.body = matrix.event.body.replace(linkRegex, "<a href='$1://$2'>$3</a>");
+    matrix.event.body = matrix.event.body.replace(linkRegex2, "<a href='$1://$2'>$1://$2</a>");
+    matrix.event.body = matrix.event.body.replace(mailtoRegex, "<a href='mailto:$1'>$2</a>");
+    matrix.event.body = matrix.event.body.replace(mailtoRegex2, "<a href='mailto:$1'>mailto:$1</a>");
+
+    // TODO: Put this somewhere else
+    // Handle Slack Multiline Messages
+    matrix.event.body = matrix.event.body.replace('\n', '<br>');
+};


### PR DESCRIPTION
Fixes #14 

Probably not the best or elegant way, but it works.

I have not handled `<@user:matrix.org|Bob>` and `<#room:matrix.org|Room>` because I don't think adds much value? (and it's more work)

I probably haven't done the `Only do transforms on slack endpoint.` which is mentioned in #14, but I don't know how to check that / what that means.

The `\n` to `<br>` replacement should probably be moved to where #5 gets implemented, but my example (AppVeyor notifications) uses it, so I put it here.