### PR TITLE
Pin Dockerfile to Node 10.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:10-alpine
 
 COPY . /
 


### PR DESCRIPTION
The docker tag `node:alpine` currently pulls a Node 11.x image but the sqlite library (https://github.com/mapbox/node-sqlite3) does not advertise any support for Node 11.x in its README and building it on Node 11.x with the current Dockerfile results in a ton of errors. Pinning the image to Node 10.x solves the build problems.