### PR TITLE
Fix Breaking Change of cheerio

### DIFF
--- a/src/processing/layers/avatar/slack_icon_emoji.js
+++ b/src/processing/layers/avatar/slack_icon_emoji.js
@@ -10,7 +10,7 @@ module.exports = (webhook, matrix) => {
         const imgElement = emojione.shortnameToImage(webhook.icon_emoji);
         if (imgElement == webhook.icon_emoji) return;
 
-        const srcUrl = cheerio(imgElement).attr('src');
+        const srcUrl = cheerio.load(imgElement).attr('src');
         matrix.sender.avatarUrl = srcUrl;
     }
 };


### PR DESCRIPTION
Cheerio node module cause a fatal ERROR:  
```
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]: [ERROR] TypeError: cheerio is not a function
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at module.exports (/src/processing/layers/avatar/slack_icon_emoji.js:13:24)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at layerChain.then (/src/processing/WebhookReceiver.js:69:75)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at tryCatcher (/node_modules/bluebird/js/release/util.js:16:23)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Promise._settlePromiseFromHandler (/node_modules/bluebird/js/release/promise.js:547:31)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Promise._settlePromise (/node_modules/bluebird/js/release/promise.js:604:18)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Promise._settlePromise0 (/node_modules/bluebird/js/release/promise.js:649:10)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Promise._settlePromises (/node_modules/bluebird/js/release/promise.js:729:18)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at _drainQueueStep (/node_modules/bluebird/js/release/async.js:93:12)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at _drainQueue (/node_modules/bluebird/js/release/async.js:86:9)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Async._drainQueues (/node_modules/bluebird/js/release/async.js:102:5)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at Immediate.Async.drainQueues [as _onImmediate] (/node_modules/bluebird/js/release/async.js:15:14)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at runCallback (timers.js:705:18)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at tryOnImmediate (timers.js:676:5)
Aug 30 22:17:41 redoo matrix-appservice-webhooks[28337]:     at processImmediate (timers.js:658:5)
```

Reason is a breaking change of cheerio RC.9:

https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0-rc.9
Was fixed by this PR